### PR TITLE
Add code to see model summaries

### DIFF
--- a/MX two stage survey coding.Rmd
+++ b/MX two stage survey coding.Rmd
@@ -209,10 +209,17 @@ for (i in 1:nrow(resp_list4)) {
                      " + satm + satv + hs_gpa + aleksikc_score")
   mod_name <- paste0("modeleff_", i)
   cat(formula_, "\n\n")
-  assign(mod_name, polr(formula_, data = master_two_stage))
+  assign(mod_name, polr(formula_, data = master_two_stage, Hess = TRUE))
 }
 
 ```
+```{r}
+summary(modeleff_1)
+summary(modeleff_2)
+summary(modeleff_3)
+summary(modeleff_4)
+```
+
 
 ```{r}
 x1 <- c("perts_q1relevplan2_of", "perts_q2relevskills2_of", "perts_q3relevwork2_of","perts_q4relevfuture2_of")
@@ -228,9 +235,15 @@ for (i in 1:nrow(resp_list3)) {
                      " + satm + satv + hs_gpa + aleksikc_score")
   mod_name <- paste0("modelrele_", i)
   cat(formula_, "\n\n")
-  assign(mod_name, polr(formula_, data = master_two_stage))
+  assign(mod_name, polr(formula_, data = master_two_stage, Hess = TRUE))
 }
 
+```
+```{r}
+summary(modelrele_1)
+summary(modelrele_2)
+summary(modelrele_3)
+summary(modelrele_4)
 ```
 
 ```{r}
@@ -247,10 +260,19 @@ for (i in 1:nrow(resp_list2)) {
                      " + satm + satv + hs_gpa + aleksikc_score")
   mod_name <- paste0("modelbelong_", i)
   cat(formula_, "\n\n")
-  assign(mod_name, polr(formula_, data = master_two_stage))
+  assign(mod_name, polr(formula_, data = master_two_stage, Hess = TRUE))
 }
 
 ```
+
+```{r}
+summary(modelbelong_1)
+summary(modelbelong_2)
+summary(modelbelong_3)
+summary(modelbelong_4)
+```
+
+
 
 ```{r}
 x1 <- c("perts_q1msfixed2_of", "perts_q2msfixed2_of", "perts_q3msfixed2_of")
@@ -266,12 +288,17 @@ for (i in 1:nrow(resp_list1)) {
                      " + satm + satv + hs_gpa + aleksikc_score")
   mod_name <- paste0("modelms_", i)
   cat(formula_, "\n\n")
-  assign(mod_name, polr(formula_, data = master_two_stage))
+  assign(mod_name, polr(formula_, data = master_two_stage, Hess = TRUE))
 }
 
 ```
 
 
+```{r}
+summary(modelms_1)
+summary(modelms_2)
+summary(modelms_3)
+```
 
 
 


### PR DESCRIPTION
When running several of the `polr` models in this script, I got the following warning:

> Warning: design appears to be rank-deficient, so dropping some coefs

This indicates that two or more of the predictor variables in the model are linearly correlated; that is, only one of them is needed to uniquely identify the model (I think this is a bit over-simplified, but it's the general idea). So, it appears that R will automatically drop one or more coeffs that are collinear with another coeff. (Here's some info about [multicollinearity](https://www.analyticsvidhya.com/blog/2020/03/what-is-multicollinearity/).)

The function [`perturb`](https://stats.stackexchange.com/questions/35233/how-to-test-for-and-remedy-multicollinearity-in-optimal-scaling-ordinal-regressi) can apparently help us determine which of our predictors are collinear. So, we can try that sometime I guess. 😒

Here are the changes I've implemented in this update:

* Include `summary()` calls for each model created
* Include `Hess = TRUE` in the `polr()` function calls. This ensures that a summary of the model can be extracted even when we recieve the "rank deficient" warning. At least, that's what I gleaned from this thread on StackExchange: https://stats.stackexchange.com/questions/166566/multicollinearity-problems-with-polr-function-in-the-mass-package-for-ordinal